### PR TITLE
ci: use reusable ci-node workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,36 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
-
-  test:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm test -- --coverage --ci
-
-  build:
-    runs-on: self-hosted
-    needs: [lint, test]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run build
+  node:
+    uses: CosmicBytez/.github/.github/workflows/ci-node.yml@v1
+    with:
+      node-version: "22"
+      test-command: npm test -- --coverage --ci


### PR DESCRIPTION
Migrate CI to the org-wide reusable workflow at `CosmicBytez/.github/.github/workflows/ci-node.yml@v1`.

**Behavior unchanged**: same Node 22, same self-hosted runner, same job steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)