### PR TITLE
fix: bump concurrently to patch critical shell-quote advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5981,15 +5981,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -13279,9 +13279,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
Bumps `concurrently` 9.2.1 → 9.2.3 (lockfile-only), which pulls `shell-quote` 1.8.3 → 1.8.4 and resolves **2 CRITICAL** npm advisories — `shell-quote` `quote()` does not escape newlines in object `.op` values (vulnerable range 1.1.0–1.8.3).

## Risk
- `concurrently` is **dev-only** (`electron:dev`). Neither `next build` nor the static-export `build:electron` release gate invokes it.
- `package.json` range `^9.2.1` already covers 9.2.3 — **no manifest change**, lockfile only (`package-lock.json`, 7 insertions / 7 deletions).

## Verification
- `npm audit` critical **2 → 0** (35 → 33 total)
- Both Next builds pass
- 257 Jest tests + eslint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
